### PR TITLE
Fix for iPad sizing

### DIFF
--- a/PhotoTweaks/PhotoTweaks/PhotoTweaksViewController.m
+++ b/PhotoTweaks/PhotoTweaks/PhotoTweaksViewController.m
@@ -40,7 +40,10 @@
     
     self.view.clipsToBounds = YES;
     self.view.backgroundColor = [UIColor photoTweakCanvasBackgroundColor];
-    
+}
+
+-(void)viewWillAppear:(BOOL)animated{
+    [super viewWillAppear:animated];
     [self setupSubviews];
 }
 


### PR DESCRIPTION
If shown in a popover, then the view thinks it's width is 768.
